### PR TITLE
Add config prop

### DIFF
--- a/src/components/Plotly.vue
+++ b/src/components/Plotly.vue
@@ -22,6 +22,9 @@ export default {
     layout: {
       type: Object
     },
+    config: {
+      type: Object
+    },
     id: {
       type: String,
       required: false,
@@ -69,6 +72,7 @@ export default {
       }, {});
       return {
         responsive: false,
+        ...(this.config || {}),
         ...optionsFromAttrs
       };
     }


### PR DESCRIPTION
This way, a config object that might otherwise be passed to
`Plotly.setPlotConfig()` or as the last argument to `Plotly.newPlot()`,
can be passed to the `Plotly` Vue component.  It is still possible to
pass individial config props that get merged into the resulting config
object, but using the new config prop allows for encapsulation of
configuration as well as reuse and may help keep things tidier.