### PR TITLE
Fix path to module entry point in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/David-Desmaisons/vue-plotly.git"
   },
   "main": "dist/vue-plotly.umd.js",
-  "module": "dist/vue-plotly.common.min.js",
+  "module": "dist/vue-plotly.common.js",
   "files": [
     "dist/*.css",
     "dist/*.map",


### PR DESCRIPTION
The file `dist/vue-plotly.common.min.js` does not exist in the published npm package.
This change sets the module path to the existing file `dist/vue-plotly.common.js`.

In combination with #52 this enables the use of this package in vite (vue 2.7), fixing #47.