### PR TITLE
Use package-lock.json in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,16 +22,16 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
+          - v1-dependencies-{{ checksum "package-lock.json" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: yarn install
+      - run: npm ci
 
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: v1-dependencies-{{ checksum "package-lock.json" }}
         
       # run tests!
       - run: yarn test:coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,6 @@ jobs:
           key: v1-dependencies-{{ checksum "package-lock.json" }}
         
       # run tests!
-      - run: yarn test:coverage
+      - run: npm run test:coverage
 
 


### PR DESCRIPTION
Use npm instead of yarn in CircleCI pipeline, because `package-lock.json` is not respected by yarn.

fixes #51 